### PR TITLE
Add support for the a00097382 bulletin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 check_hp_disk_firmware
-=================
+======================
 
 ![Go build](https://github.com/NETWAYS/check_hp_disk_firmware/workflows/Go/badge.svg?branch=master)
 
-Icinga / Nagios check plugin to verify SSD disks are not affected by the `a00092491` bulletin from HPE.
+Icinga / Nagios check plugin to verify SSD disks are not affected by the `a00092491` or `a00097382` bulletin from HPE.
 
 > HPE SAS Solid State Drives - Critical Firmware Upgrade Required for Certain HPE SAS Solid State Drive Models to
-> Prevent Drive Failure at 32,768 Hours of Operation
+> Prevent Drive Failure at 32,768 or 40,000 Hours of Operation
 
-Please see [support document from HPE](https://support.hpe.com/hpsc/doc/public/display?docId=emr_na-a00092491en_us).
+Please see support documents from HPE:
+* [a00092491](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=emr_na-a00092491en_us)
+* [a00097382](https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us)
 
 ## Usage
 

--- a/hp/drive.go
+++ b/hp/drive.go
@@ -80,8 +80,8 @@ func (d *PhysicalDrive) GetNagiosStatus() (int, string) {
 		return nagios.Critical, description + " - status: " + d.Status
 	}
 
-	if _, affected := AffectedModels[d.Model]; affected {
-		ok, err := IsFirmwareFixed(d.FwRev)
+	if model, affected := AffectedModels[d.Model]; affected {
+		ok, err := IsFirmwareFixed(model, d.FwRev)
 		if err != nil {
 			return nagios.Unknown, description + " - error: " + err.Error()
 		} else if ok {

--- a/hp/drive_test.go
+++ b/hp/drive_test.go
@@ -1,0 +1,48 @@
+package hp
+
+import (
+	"github.com/NETWAYS/check_hp_disk_firmware/nagios"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+const affectedDrive = "VO0480JFDGT"
+const affectedDriveFixed = "HPD8"
+
+func TestPhysicalDrive_GetNagiosStatus(t *testing.T) {
+	drive := &PhysicalDrive{
+		Id:     "1.1",
+		Model:  "OTHERDRIVE",
+		FwRev:  "HPD1",
+		Serial: "ABC123",
+		Status: "ok",
+		Hours:  1337,
+	}
+
+	var status int
+	var info string
+
+	// good
+	status, info = drive.GetNagiosStatus()
+	assert.Equal(t, nagios.OK, status)
+	assert.Regexp(t, `\(1\.1 \) model=\w+ serial=ABC123 firmware=HPD1 hours=1337`, info)
+
+	// failed
+	drive.Status = "failed"
+	status, info = drive.GetNagiosStatus()
+	assert.Equal(t, nagios.Critical, status)
+	assert.Regexp(t, `\(1\.1 \) model=\w+ serial=ABC123 firmware=HPD1 hours=1337 - status: failed`, info)
+
+	// affected
+	drive.Status = "ok"
+	drive.Model = affectedDrive
+	status, info = drive.GetNagiosStatus()
+	assert.Equal(t, nagios.Critical, status)
+	assert.Regexp(t, `^\(1\.1 \) model=\w+ serial=ABC123 firmware=HPD1 hours=1337 - affected`, info)
+
+	// affected but fixed
+	drive.FwRev = affectedDriveFixed
+	status, info = drive.GetNagiosStatus()
+	assert.Equal(t, nagios.OK, status)
+	assert.Regexp(t, `^\(1\.1 \) model=\w+ serial=ABC123 firmware=\w+ hours=1337 - .*applied`, info)
+}

--- a/hp/firmware.go
+++ b/hp/firmware.go
@@ -12,6 +12,12 @@ import (
 
 const FixedA = "HPD8"
 
+// Source B: https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us
+// Version: 1
+// Last Updated: 2020-03-20
+
+const FixedB = "HPD7"
+
 type AffectedModel struct {
 	ModelNo       string
 	Description   string
@@ -20,6 +26,7 @@ type AffectedModel struct {
 
 //AffectedModelList list of model numbers for drives that are affected with their description as value
 var AffectedModelList = []*AffectedModel{
+	// Drives from bulletin A
 	{"VO0480JFDGT", "HP 480 GB 12 Gbit SAS 2.5\" RI PLP SC SSD", FixedA},
 	{"VO0960JFDGU", "HP 960GB 12 Gbit SAS 2.5\" RI PLP SC SSD", FixedA},
 	{"VO1920JFDGV", "HP 1,92 TB 12 Gbit SAS 2.5\" RI PLP SC SSD", FixedA},
@@ -41,6 +48,12 @@ var AffectedModelList = []*AffectedModel{
 	//{"VK003840JWSST", "HPE 3,84 TB SAS RI LFF SCC DS SPL SSD", FixedA},
 	{"VK007680JWSSU", "HPE 7,68 TB SAS RI SFF SC DS SSD", FixedA},
 	{"VO015300JWSSV", "HPE 15,3 TB SAS RI SFF SC DS SSD", FixedA},
+
+	// Drives from bulletin B
+	{"EK0800JVYPN", "HPE 800GB 12G SAS WI-1 SFF SC SSD", FixedB},
+	{"EO1600JVYPP", "HPE 1.6TB 12G SAS WI-1 SFF SC SSD", FixedB},
+	{"MK0800JVYPQ", "HPE 800GB 12G SAS MU-1 SFF SC SSD", FixedB},
+	{"MO1600JVYPR", "HPE 1.6TB 12G SAS MU-1 SFF SC SSD", FixedB},
 }
 
 type AffectedIndex map[string]*AffectedModel

--- a/hp/firmware_test.go
+++ b/hp/firmware_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 )
 
-const testModel = "VO0480JFDGT"
+const testModelA = "VO0480JFDGT"
+const testModelB = "EK0800JVYPN"
 
 func TestIsAffected(t *testing.T) {
 	assert.False(t, IsAffected("UNKNOWN"))
-	assert.True(t, IsAffected(testModel))
+	assert.True(t, IsAffected(testModelA))
 }
 
 func TestSplitFirmware(t *testing.T) {
@@ -28,7 +29,7 @@ func TestSplitFirmware(t *testing.T) {
 }
 
 func TestIsFirmwareFixed(t *testing.T) {
-	tests := map[string]bool{
+	testsA := map[string]bool{
 		"HPD5":  false,
 		"HPD7":  false,
 		"HPD8":  true,
@@ -36,10 +37,23 @@ func TestIsFirmwareFixed(t *testing.T) {
 		"HPD10": true,
 	}
 
-	model := AffectedModels[testModel]
+	modelA := AffectedModels[testModelA]
+	for fw, expect := range testsA {
+		ok, err := IsFirmwareFixed(modelA, fw)
+		assert.Equal(t, expect, ok)
+		assert.NoError(t, err)
+	}
 
-	for fw, expect := range tests {
-		ok, err := IsFirmwareFixed(model, fw)
+	testsB := map[string]bool{
+		"HPD5": false,
+		"HPD6": false,
+		"HPD7": true,
+		"HPD8": true,
+	}
+
+	modelB := AffectedModels[testModelB]
+	for fw, expect := range testsB {
+		ok, err := IsFirmwareFixed(modelB, fw)
 		assert.Equal(t, expect, ok)
 		assert.NoError(t, err)
 	}

--- a/hp/firmware_test.go
+++ b/hp/firmware_test.go
@@ -5,6 +5,28 @@ import (
 	"testing"
 )
 
+const testModel = "VO0480JFDGT"
+
+func TestIsAffected(t *testing.T) {
+	assert.False(t, IsAffected("UNKNOWN"))
+	assert.True(t, IsAffected(testModel))
+}
+
+func TestSplitFirmware(t *testing.T) {
+	prefix, version, err := SplitFirmware("HPD5")
+	assert.Equal(t, "HPD", prefix)
+	assert.Equal(t, 5, version)
+	assert.Nil(t, err)
+
+	prefix, version, err = SplitFirmware("HPD10")
+	assert.Equal(t, "HPD", prefix)
+	assert.Equal(t, 10, version)
+	assert.Nil(t, err)
+
+	prefix, version, err = SplitFirmware("1HPD5")
+	assert.Error(t, err)
+}
+
 func TestIsFirmwareFixed(t *testing.T) {
 	tests := map[string]bool{
 		"HPD5":  false,
@@ -14,9 +36,15 @@ func TestIsFirmwareFixed(t *testing.T) {
 		"HPD10": true,
 	}
 
+	model := AffectedModels[testModel]
+
 	for fw, expect := range tests {
-		ok, err := IsFirmwareFixed(fw)
+		ok, err := IsFirmwareFixed(model, fw)
 		assert.Equal(t, expect, ok)
 		assert.NoError(t, err)
 	}
+
+	otherModel := &AffectedModel{"ABC", "nothing", "HPX11"}
+	_, err := IsFirmwareFixed(otherModel, "HPD5")
+	assert.Error(t, err)
 }


### PR DESCRIPTION
Source: https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00097382en_us

The hardest part was to refactor the version comparison, so it will work with different versions per model.